### PR TITLE
Feat/html adt

### DIFF
--- a/Html.hs
+++ b/Html.hs
@@ -1,7 +1,6 @@
 module Html
   ( Html,
     Title,
-    Structure,
     Attribute,
     html_,
     h_,
@@ -9,11 +8,14 @@ module Html
     br_,
     strong_,
     em_,
-    quote_,
-    ul_,
-    ol_,
+    bi_,
     code_,
-    render,
+    codeBlock_,
+    quote_,
+    ol_,
+    ul_,
+    attr,
+    escape,
   )
 where
 

--- a/Html/Internal.hs
+++ b/Html/Internal.hs
@@ -21,6 +21,33 @@ h_ n = el ("h" <> show n)
 p_ :: Html -> Html
 p_ = el "p"
 
+br_ :: Html
+br_ = iel "br"
+
+strong_ :: Html -> Html
+strong_ = el "strong"
+
+em_ :: Html -> Html
+em_ = el "em"
+
+-- bold italic
+bi_ :: Html -> Html
+bi_ = strong_ . em_
+
+quote_ :: Html -> Html
+quote_ = ela "div" [attr "class" "quote"]
+
+-- Little bit jank for the list elements, but only need to fix if other
+-- functions require concat HTML
+ol_ :: [Html] -> Html
+ol_ items = el "ol" (Structure (Element (concatMap (getHtmlString . li_) items)))
+
+ul_ :: [Html] -> Html
+ul_ items = el "ul" (Structure (Element (concatMap (getHtmlString . li_) items)))
+
+li_ :: Html -> Html
+li_ = el "li"
+
 el :: String -> Html -> Html
 el tag content =
   Structure (Element (ot tag <> getHtmlString content <> ct tag))
@@ -54,13 +81,16 @@ ct tag = "</" <> tag <> ">"
 attr :: String -> String -> Attribute
 attr a s = Attribute (a <> "=\"" <> s <> "\"")
 
+concatHtml :: [Html] -> Html
+concatHtml = Structure . Element . concatMap getHtmlString
+
 getHtmlString :: Html -> String
 getHtmlString content = case content of
   (Text s) -> (\(EscapedString e) -> e) s
   (Structure s) -> (\(Element e) -> e) s
 
 getAttributesString :: [Attribute] -> String
-getAttributesString attributes = unwords (map (\(Attribute x) -> x) attributes)
+getAttributesString attributes = ' ' : unwords (map (\(Attribute x) -> x) attributes)
 
 -- This is the only way to create an EscapedString
 escape :: String -> EscapedString

--- a/Html/Internal.hs
+++ b/Html/Internal.hs
@@ -30,9 +30,12 @@ html_ title content =
       [attr "lang" "en"]
       ( el
           "head"
-          ( iela "meta" [attr "charset" "UTF-8"]
+          ( el "title" (escape title)
+              <> iela "meta" [attr "charset" "UTF-8"]
               <> iela "meta" [attr "name" "viewport", attr "content" "width=device-width, initial-scale=1.0"]
-              <> el "title" (escape title)
+              <> iela "link" [attr "rel" "stylesheet", attr "href" "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/default.min.css"]
+              <> iela "script" [attr "src" "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js"]
+              <> el "script" (Html "hljs.highlightAll();")
           )
           <> el "body" content
       )

--- a/Html/Internal.hs
+++ b/Html/Internal.hs
@@ -2,101 +2,50 @@
 
 module Html.Internal where
 
-import GHC.Num (Natural)
-
 -- This data type exists because there are times where
 -- we can pass either an html structure or an escaped string.
 -- eg. <p> <em> bold </em> </p>
-data Html = Elements Structure | Text String
+data Html = Structure Element | Text EscapedString
 
-newtype Structure = Structure String
+newtype Element = Element String
+
+newtype EscapedString = EscapedString String
 
 newtype Attribute = Attribute String
 
-type Title = String
+el :: String -> Html -> Html
+el tag content =
+  Structure (Element (ot tag <> getHtmlString content <> ct tag))
 
--- This function is just cursed.
--- It is meant to create an html template
-html_ :: String -> Structure -> Html
-html_ title content =
-  Text
-    ( el
-        "html"
-        ( el "head" (el "title" (escape title))
-            <> el "body" (getStructureString content)
+ela :: String -> [Attribute] -> Html -> Html
+ela tag attributes content =
+  Structure
+    ( Element
+        ( ota tag attributes
+            <> getHtmlString content
+            <> ct tag
         )
     )
 
-h_ :: Natural -> Html -> Structure
-h_ n = Structure . el ("h" <> show n) . escape
+ota :: String -> [Attribute] -> String
+ota tag attributes = "<" <> tag <> unwords (map (\(Attribute x) -> x) attributes) <> ">"
 
-p_ :: String -> Structure
-p_ = Structure . el "p" . escape
+ot :: String -> String
+ot tag = "<" <> tag <> ">"
 
-br_ :: Structure
-br_ = Structure "<br>"
-
-strong_ :: String -> Structure
-strong_ = Structure . el "strong" . escape
-
-em_ :: String -> Structure
-em_ = Structure . el "em" . escape
-
-quote_ :: Structure -> Structure
-quote_ = Structure . div_ "quote"
-
-ol_ :: [Structure] -> Structure
-ol_ =
-  let li_ = el "li"
-   in Structure . el "ol" . concatMap (li_ . getStructureString)
-
-ul_ :: [Structure] -> Structure
-ul_ =
-  let li_ = el "li"
-   in Structure . el "ul" . concatMap (li_ . getStructureString)
-
-code_ :: [Char] -> Structure
-code_ = Structure . el "code" . escape
-
--- img_ :: String -> String -> Structure
-
--- internal
-div_ :: String -> Structure -> String
-div_ c = ela "div" [attr "class" c]
-
-el :: String -> String -> String
-el tag content = "<" <> tag <> ">" <> content <> "</" <> tag <> ">"
-
-ela :: String -> [Attribute] -> Structure -> String
-ela tag attrs content =
-  case attrs of
-    [] -> el tag (getStructureString content)
-    _ ->
-      "<"
-        <> tag
-        <> " "
-        <> unwords (map getAttributeString attrs)
-        <> ">"
-        <> getStructureString content
-        <> "</"
-        <> tag
-        <> ">"
-
-getAttributeString :: Attribute -> String
-getAttributeString (Attribute s) = s
+ct :: String -> String
+ct tag = "</" <> tag <> ">"
 
 attr :: String -> String -> Attribute
 attr a s = Attribute (a <> "=\"" <> s <> "\"")
 
--- If you squint, (Structure str) is how we create a variable of type Structure
--- Since everything is functional, having this definition in the args
--- gives us access to the underlying data.
-getStructureString :: Structure -> String
-getStructureString (Structure str) = str
+getHtmlString :: Html -> String
+getHtmlString content = case content of
+  (Text s) -> (\(EscapedString e) -> e) s
+  (Structure s) -> (\(Element e) -> e) s
 
--- I feel like escaping should not be the responsibility of
---  the html library
-escape :: [Char] -> [Char]
+-- This is the only way to create an EscapedString
+escape :: String -> EscapedString
 escape =
   let escapeChar c =
         case c of
@@ -106,15 +55,6 @@ escape =
           '"' -> "&quot;"
           '\'' -> "&#39;"
           _ -> [c]
-   in concatMap escapeChar
+   in EscapedString . concatMap escapeChar
 
-instance Semigroup Structure where
-  (<>) :: Structure -> Structure -> Structure
-  (<>) a b =
-    Structure (getStructureString a <> getStructureString b)
-
-render :: Html -> String
-render a =
-  case a of
-    (Text t) -> t
-    (Elements e) -> getStructureString e
+type Title = String

--- a/Html/Internal.hs
+++ b/Html/Internal.hs
@@ -2,6 +2,8 @@
 
 module Html.Internal where
 
+import GHC.Natural (Natural)
+
 -- This data type exists because there are times where
 -- we can pass either an html structure or an escaped string.
 -- eg. <p> <em> bold </em> </p>
@@ -12,6 +14,12 @@ newtype Element = Element String
 newtype EscapedString = EscapedString String
 
 newtype Attribute = Attribute String
+
+h_ :: Natural -> Html -> Html
+h_ n = el ("h" <> show n)
+
+p_ :: Html -> Html
+p_ = el "p"
 
 el :: String -> Html -> Html
 el tag content =
@@ -27,8 +35,15 @@ ela tag attributes content =
         )
     )
 
+iel :: String -> Html
+iel tag = Structure (Element ("<" <> tag <> " />"))
+
+iela :: String -> [Attribute] -> Html
+iela tag attributes =
+  Structure (Element ("<" <> tag <> getAttributesString attributes <> " />"))
+
 ota :: String -> [Attribute] -> String
-ota tag attributes = "<" <> tag <> unwords (map (\(Attribute x) -> x) attributes) <> ">"
+ota tag attributes = "<" <> tag <> getAttributesString attributes <> ">"
 
 ot :: String -> String
 ot tag = "<" <> tag <> ">"
@@ -43,6 +58,9 @@ getHtmlString :: Html -> String
 getHtmlString content = case content of
   (Text s) -> (\(EscapedString e) -> e) s
   (Structure s) -> (\(Element e) -> e) s
+
+getAttributesString :: [Attribute] -> String
+getAttributesString attributes = unwords (map (\(Attribute x) -> x) attributes)
 
 -- This is the only way to create an EscapedString
 escape :: String -> EscapedString

--- a/Html/Internal.hs
+++ b/Html/Internal.hs
@@ -34,16 +34,17 @@ em_ = el "em"
 bi_ :: Html -> Html
 bi_ = strong_ . em_
 
+code_ :: Html -> Html
+code_ = el "code"
+
 quote_ :: Html -> Html
 quote_ = ela "div" [attr "class" "quote"]
 
--- Little bit jank for the list elements, but only need to fix if other
--- functions require concat HTML
 ol_ :: [Html] -> Html
-ol_ items = el "ol" (Structure (Element (concatMap (getHtmlString . li_) items)))
+ol_ items = el "ol" (concatHtml (map li_ items))
 
 ul_ :: [Html] -> Html
-ul_ items = el "ul" (Structure (Element (concatMap (getHtmlString . li_) items)))
+ul_ items = el "ul" (concatHtml (map li_ items))
 
 li_ :: Html -> Html
 li_ = el "li"
@@ -62,9 +63,11 @@ ela tag attributes content =
         )
     )
 
+-- Inline element
 iel :: String -> Html
 iel tag = Structure (Element ("<" <> tag <> " />"))
 
+-- Inline element with attributes. Maybe fix with monads or whatever in future
 iela :: String -> [Attribute] -> Html
 iela tag attributes =
   Structure (Element ("<" <> tag <> getAttributesString attributes <> " />"))

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 markdown -> html, written in haskell
 
+## idea history
+I wanted to keep everythin clean, so at first, I created separate types for strings that have been escaped to HTML, and actual HTML structures. 
+However, as I developed the library, I releazed that an escaped string and an HTML structure were functionally identical. However, it is still useful to keep a type "EscapedString" because it gives a hint as to the uses. Although functionally equivalent, you would not want to pass in an actual html structure into a code block (usually). 
+
 ## devlog
 - early dev, decided on supporting "basic sytanx" in markdown
   - code blocks should be fenced

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 markdown -> html, written in haskell
 
 ## idea history
+Maybe I can implement a "wrapper" for everything that just passes in the calls the escape function for me. 
+
 I wanted to keep everythin clean, so at first, I created separate types for strings that have been escaped to HTML, and actual HTML structures. 
 However, as I developed the library, I releazed that an escaped string and an HTML structure were functionally identical. However, it is still useful to keep a type "EscapedString" because it gives a hint as to the uses. Although functionally equivalent, you would not want to pass in an actual html structure into a code block (usually). 
 

--- a/build/index.html
+++ b/build/index.html
@@ -1,38 +1,14 @@
-<html>
-
+<!DOCTYPE html>
+<html lang="en">
 <head>
-    <title>my title</title>
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Apple macOS version 5.8.0">
+  <meta charset="UTF-8">
+  <meta name="viewport" content=
+  "width=device-width, initial-scale=1.0">
+  <title>ur mom</title>
 </head>
-
-<body><code>print(&#39;hello world&#39;)</code>
-    <div class="quote">
-        <h1>Quote <em>para in h</em>
-        </h1>
-        <p>blah</p>
-    </div>
-    <p>p1</p><br>
-    <p>p2</p>
-    <test class="lmao" id="balls">
-        <p>lmao</p>
-    </test>
-    <ul>
-        <li>
-            <p>list</p>
-        </li>
-        <li>
-            <p>lmao</p>
-        </li>
-        <li>
-            <ol>
-                <li>
-                    <p>ordered</p>
-                </li>
-                <li>
-                    <p>lol</p>
-                </li>
-            </ol>
-        </li>
-    </ul>
+<body>
+  <h1>Hello, World!</h1>
 </body>
-
 </html>

--- a/build/index.html
+++ b/build/index.html
@@ -3,10 +3,17 @@
 <head>
   <meta name="generator" content=
   "HTML Tidy for HTML5 for Apple macOS version 5.8.0">
+  <title>This is your title</title>
   <meta charset="UTF-8">
   <meta name="viewport" content=
   "width=device-width, initial-scale=1.0">
-  <title>This is your title</title>
+  <link rel="stylesheet" href=
+  "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/styles/default.min.css">
+  <script src=
+  "https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.11.1/highlight.min.js"></script>
+  <script>
+  hljs.highlightAll();
+  </script>
 </head>
 <body>
   <h1>This is a h1</h1>

--- a/build/index.html
+++ b/build/index.html
@@ -6,9 +6,71 @@
   <meta charset="UTF-8">
   <meta name="viewport" content=
   "width=device-width, initial-scale=1.0">
-  <title>ur mom</title>
+  <title>This is your title</title>
 </head>
 <body>
-  <h1>Hello, World!</h1>
+  <h1>This is a h1</h1>
+  <h2>This is a h2</h2>
+  <h3>This is a h3</h3>
+  <h4>This is a h4</h4>
+  <h5>This is a h5</h5>
+  <h6>This is a h6</h6>
+  <p>This is a paragraph.</p>
+  <p>This is another paragraph.<br>
+  With a line break.</p>
+  <p>How about some <strong>bold?</strong> Or perhaps some
+  <em>italics?</em> <strong><em>Both?</em></strong></p>
+  <p>Maybe some inline <code>code</code>?</p>
+  <pre><code class="language-python"># Python more your style?
+print('Hello, World!')</code></pre>
+  <div class="quote">
+    <p>"Haskell is the world's finest imperative language."</p>
+    <p><em>— Simon Peyton Jones</em></p>
+  </div>
+  <p>Pros of Haskell:</p>
+  <ol>
+    <li>
+      <p>Pure Functional Programming</p>
+    </li>
+    <li>
+      <p>Strong, Static Type System</p>
+    </li>
+    <li>
+      <p>Excellent Abstractions</p>
+    </li>
+    <li>
+      <p>Great for Compilers and DSLs</p>
+    </li>
+    <li>
+      <p>Lazy Evaluation</p>
+    </li>
+    <li>
+      <p>High Performance (when tuned)</p>
+    </li>
+    <li>
+      <p>Rich Ecosystem for Academic and Research-Grade Tools</p>
+    </li>
+  </ol>
+  <p>Cons of Haskell:</p>
+  <ul>
+    <li>
+      <p>Steep Learning Curve</p>
+    </li>
+    <li>
+      <p>Laziness Can Be Tricky</p>
+    </li>
+    <li>
+      <p>Smaller Ecosystem</p>
+    </li>
+    <li>
+      <p>Cryptic Error Messages</p>
+    </li>
+    <li>
+      <p>Dependency Hell in Some Ecosystems</p>
+    </li>
+    <li>
+      <p>Smaller Community and Hiring Pool</p>
+    </li>
+  </ul>
 </body>
 </html>

--- a/main.hs
+++ b/main.hs
@@ -1,49 +1,13 @@
 {-# OPTIONS_GHC -Wall #-}
 
-import Html.Internal
-  ( Attribute,
-    Html,
-    Structure (..),
-    Title,
-    attr,
-    br_,
-    code_,
-    ela,
-    em_,
-    h_,
-    html_,
-    ol_,
-    p_,
-    quote_,
-    render,
-    strong_,
-    ul_,
-  )
+import Html
+import System.Process (readProcess)
 
+-- evil jank
 main :: IO ()
-main = writeFile "build/index.html" (render page)
-
-test :: String
-test = ela "test" [attr "class" "lmao", attr "id" "balls"] (p_ "lmao")
+main = do
+  formatted <- readProcess "tidy" ["-indent", "-quiet"] (show page)
+  writeFile "build/index.html" formatted
 
 page :: Html
-page =
-  html_
-    "my title"
-    ( code_ "print('hello world')"
-        <> quote_ (h_ 1 "Quote" <> p_ "blah")
-        <> ( p_ "p1"
-               <> br_
-               <> p_ "p2"
-               <> Structure test
-               <> ul_
-                 [ p_ "list",
-                   p_ "lmao",
-                   ol_ [p_ "ordered", p_ "lol"],
-                   --  problem: input should either be escaped text
-                   --  or an html structure. Should be solved using a data type.
-                   --  Weird styles can be acheived. I will just let it be.
-                   p_ em_ "italics"
-                 ]
-           )
-    )
+page = html_ "ur mom" (h_ 1 (escape "Hello, World!"))

--- a/main.hs
+++ b/main.hs
@@ -10,4 +10,38 @@ main = do
   writeFile "build/index.html" formatted
 
 page :: Html
-page = html_ "ur mom" (h_ 1 (escape "Hello, World!"))
+page =
+  html_
+    "This is your title"
+    ( h_ 1 (escape "This is a h1")
+        <> h_ 2 (escape "This is a h2")
+        <> h_ 3 (escape "This is a h3")
+        <> h_ 4 (escape "This is a h4")
+        <> h_ 5 (escape "This is a h5")
+        <> h_ 6 (escape "This is a h6")
+        <> p_ (escape "This is a paragraph.")
+        <> p_ (escape "This is another paragraph." <> br_ <> escape "With a line break.")
+        <> p_ (escape "How about some " <> strong_ (escape "bold? ") <> escape "Or perhaps some " <> em_ (escape "italics? ") <> bi_ (escape "Both? "))
+        <> p_ (escape "Maybe some inline " <> code_ (escape "code") <> escape "? ")
+        <> codeBlock_ "python" (escape "# Python more your style?\nprint('Hello, World!')")
+        <> quote_ (p_ (escape "\"Haskell is the world's finest imperative language.\"") <> p_ (em_ (escape "— Simon Peyton Jones")))
+        <> p_ (escape "Pros of Haskell: ")
+        <> ol_
+          [ p_ (escape "Pure Functional Programming"),
+            p_ (escape "Strong, Static Type System"),
+            p_ (escape "Excellent Abstractions"),
+            p_ (escape "Great for Compilers and DSLs"),
+            p_ (escape "Lazy Evaluation"),
+            p_ (escape "High Performance (when tuned)"),
+            p_ (escape "Rich Ecosystem for Academic and Research-Grade Tools")
+          ]
+        <> p_ (escape "Cons of Haskell: ")
+        <> ul_
+          [ p_ (escape "Steep Learning Curve"),
+            p_ (escape "Laziness Can Be Tricky"),
+            p_ (escape "Smaller Ecosystem"),
+            p_ (escape "Cryptic Error Messages"),
+            p_ (escape "Dependency Hell in Some Ecosystems"),
+            p_ (escape "Smaller Community and Hiring Pool")
+          ]
+    )


### PR DESCRIPTION
Finish the HTML building library.

## idea history
Maybe I can implement a "wrapper" for everything that just passes in the calls the escape function for me. 

I wanted to keep everythin clean, so at first, I created separate types for strings that have been escaped to HTML, and actual HTML structures. 
However, as I developed the library, I releazed that an escaped string and an HTML structure were functionally identical. However, it is still useful to keep a type "EscapedString" because it gives a hint as to the uses. Although functionally equivalent, you would not want to pass in an actual html structure into a code block (usually). 

## devlog
- early dev, decided on supporting "basic sytanx" in markdown
  - code blocks should be fenced
  - horizontal rules
  - us semantic html like <strong> and <em>
- mainly building out the required html
- code syntax highlighting should be done with highlight.js

### Problems
- input should either be escaped text or an html structure. Should be solved using a data type. Weird styles can be acheived. I will just let it be.
- escaping text should not be the responsibility of the html library
- honestly, the whole "Internal.hs" pattern is too m